### PR TITLE
Blog banner header, breadcrumb, status message, spacing

### DIFF
--- a/themes/umlib_base/css/breadcrumb.css
+++ b/themes/umlib_base/css/breadcrumb.css
@@ -10,6 +10,7 @@
 
 .breadcrumbs ol {
   display: flex;
+  flex-flow: row wrap;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -19,13 +20,17 @@
   padding-left: 0;
 }
 
-.breadcrumbs a {
+.breadcrumbs a, .breadcrumbs span {
   display: inline;
-  padding: 16px 12px;
+  padding: 16px 10px;
 }
 
 .breadcrumbs li {
-  font-size: 0;
+  padding-top: .5rem;
+}
+
+.breadcrumbs li:last-child {
+  text-transform: capitalize;
 }
 
 .breadcrumbs a {

--- a/themes/umlib_base/css/component.css
+++ b/themes/umlib_base/css/component.css
@@ -12,6 +12,14 @@
   width: 100%;
 }
 
+/* Adds styling for the status message in header */
+.umlib-messages > div> div {
+  margin-top: 1rem;
+  padding: 8px;
+  background: var(--color-teal-100);
+  border-left: solid 2px var(--color-teal-400);
+}
+
 .website-logo-link {
   margin-right: var(--space-medium);
   display: inline-block;

--- a/themes/umlib_blogs/css/base.css
+++ b/themes/umlib_blogs/css/base.css
@@ -7,14 +7,24 @@
   padding-bottom: 0;
 }
 
-#blog-page  h1 {
+#blog-page h1 {
   font-size: 2.5rem;
-  margin-top: 2rem;
-  margin-bottom: 1rem;
+  margin-top: 1rem;
+  margin-bottom: .125rem;
   border-left: solid 4px var(--color-teal-400);
   padding-bottom: 0;
   padding-left: .5rem;
 }
+
+#blog-post-page h1 {
+  font-size: 2.5rem;
+  margin-top: 2rem;
+  margin-bottom: .125rem;
+  border-left: solid 4px var(--color-teal-400);
+  padding-bottom: 0;
+  padding-left: 1rem;
+}
+
 
 /* Bullets */
 

--- a/themes/umlib_blogs/css/component.css
+++ b/themes/umlib_blogs/css/component.css
@@ -36,26 +36,24 @@ span[data-drupal-link-system-path="user"]::before {
   flex-flow: row wrap;
 }
 
-/* Blog */
+/* Blog post date */
 
-/*
-.line {
-  border: solid 1px var(--color-neutral-100);
-  width: 100%;
-  position: absolute;
-  top: 24rem;
+#block-views-block-post-date-block-1 {
+  padding-right: 0.5rem;
+  color: var(--color-neutral-300);
+  text-transform: uppercase;
+  font-weight: var(--semibold);
+  font-size: var(--text-base-size);
+  margin-bottom: .75rem;
 }
 
-#blog-page {
-  position: relative;
-}
+/* Get in Touch */
 
-@media screen and (max-width: 1080px)  {
-  .line {
-    display: none;
-  }
+.get-in-touch__block {
+  border-top: solid 1px var(--color-neutral-100);
+  padding-top: 1rem;
+  padding-bottom: 1rem;
 }
-*/
 
 /* Recent Posts */
 
@@ -75,10 +73,6 @@ span[data-drupal-link-system-path="user"]::before {
   color: var(--color-neutral-400);
   font-size: 18px;
   font-weight: var(--semibold);
-}
-
-#block-views-block-recent-posts-block-2 {
-  margin-top: 2rem;
 }
 
 .recent-posts > footer {
@@ -134,8 +128,11 @@ aside #views-exposed-form-all-posts-page-1, aside #views-exposed-form-recent-pos
 
 /* A-Z Tags */
 
-.tags {
+#a-z-page .tags {
   margin-top: 2rem;
+}
+
+.tags {
   margin-bottom: 2rem;
   padding-top: 1rem;
   border-top: solid 1px var(--color-neutral-100);
@@ -213,15 +210,12 @@ aside #views-exposed-form-all-posts-page-1, aside #views-exposed-form-recent-pos
 
 .blog-author-group {
   display: inline-flex;
-  margin-bottom: 1rem;
-  align-items: flex-start;
+  margin-top: 1rem;
+  align-items: baseline;
 }
 .blog-author-group .blog-author {
   padding-right: .5rem;
-  color: var(--color-neutral-300);
-  text-transform: uppercase;
-  font-weight: var(--semibold);
-  font-size: var(--text-base-size);
+ 
 }
 
 .blog-author-group div {
@@ -246,7 +240,7 @@ aside #views-exposed-form-all-posts-page-1, aside #views-exposed-form-recent-pos
 }
 
 .blog-post-content img {
-  max-width: 50%;
+  max-width: 75%;
   height: auto;
   display: block;
 }
@@ -429,6 +423,9 @@ aside #views-exposed-form-all-posts-page-1, aside #views-exposed-form-recent-pos
   margin-top: 2rem;
 }
 
+.post-card > div.views-field.views-field-field-blog-post-body > div > p > img{
+  max-width: 50%;
+}
 
 /* Subscribe */
 
@@ -440,6 +437,21 @@ aside #views-exposed-form-all-posts-page-1, aside #views-exposed-form-recent-pos
 .subscribe h3 {
   margin-bottom: -.75rem;
 }
+
+#block-views-block-subscribe-anon-block-1 a {
+  color: var(--color-neutral-300) !important;
+  font-weight: var(--semibold);
+  text-decoration: none !important;
+  font-size: 1.125rem;
+}
+
+#block-views-block-subscribe-anon-block-1 a::before {
+  font-family: "Material Icons";
+  content: '\e0be';
+  vertical-align: bottom;
+  padding-right: .5rem;
+  color: var(--color-neutral-300);
+} 
 
 .subscribe a {
   color: var(--color-neutral-300) !important;
@@ -454,6 +466,10 @@ aside #views-exposed-form-all-posts-page-1, aside #views-exposed-form-recent-pos
   vertical-align: bottom;
   padding-right: .5rem;
   color: var(--color-neutral-300);
+}
+
+[about="/blogs-signup"] p {
+  padding: 1rem 0;
 }
 
 /* RSS */

--- a/themes/umlib_blogs/css/layout.css
+++ b/themes/umlib_blogs/css/layout.css
@@ -10,6 +10,15 @@ main {
   padding-top: 2rem;
 }
 
+#a-z-page #block-umlib-blogs-page-title h1 {
+ margin-top: 0;
+}
+
+#a-z-page #block-exposedformall-postspage-1 {
+  margin-top: 1rem;
+ }
+ 
+
 /* Layout for Two Column Grid */
 /* A-Z page, All Posts page, Node page */
 
@@ -30,7 +39,6 @@ main {
 
 .layout-sidebar-first {
   grid-area: sidebar;
-  margin-top: 2rem;
 }
 
 .layout-sidebar-first img {
@@ -58,11 +66,41 @@ main {
   row-gap: 1rem;
   column-gap: 2rem;
   grid-template-columns: 2fr 1fr;
-  grid-template-rows: fit-content(4ch) fit-content(8ch) 1fr;
+  grid-template-rows: repeat(3, fit-content(4ch)) 1fr;
   grid-template-areas:
+       "message message"
        "bc  img"
-       "pg  img"
+       "pt  img"
+       "descr  img"
        "con sidebarblog";
+}
+
+@media screen and (max-width: 1080px)  {
+  #block-entityviewcontent-3 {
+    display: none;
+  }
+  .line {
+    display: none;;
+  }
+  .grid-two-column-with-banner {
+    display: grid;
+    row-gap: .5rem;
+    grid-template-columns: 1fr;
+    grid-template-areas:
+        "message"     
+        "bc"
+        "pt"
+        "descr"
+        "con"
+        "sidebarblog";
+  }  
+  #block-views-block-recent-posts-block-1 {
+    border-top: solid 1px var(--color-neutral-100);
+  }
+}
+
+#block-views-block-unpublished-block-block-1 {
+  grid-area: message;
 }
 
 #block-breadcrumbs-3 {
@@ -70,10 +108,15 @@ main {
 }
 
 #block-umlib-blogs-page-title {
-  grid-area: pg;
+  grid-area: pt;
 }
 
-#block-umlib-blogs-system-main > article {
+#block-entityviewcontent-2 {
+  grid-area: descr;
+  padding-left: .5rem;
+}
+
+#block-entityviewcontent-3 {
   grid-area: img;
 }
 #block-views-block-recent-posts-block-1 {
@@ -82,22 +125,18 @@ main {
 
 .sidebar-node {
   grid-area: sidebarblog;
-  max-width: 45ch;
-  margin-left: 2rem;
+  max-width: 38ch;
+  margin-left: 4rem;
 }
 
-@media screen and (max-width: 1080px)  {
-  #block-umlib-blogs-system-main > article {
-    display: none;
-  }
-  .grid-two-column-with-banner {
-    display: grid;
-    row-gap: .5rem;
-    grid-template-columns: 1fr;
-    grid-template-areas:
-         "bc"
-         "pg"
-         "con"
-         "sidebarblog";
-  }  
+.line {
+  border-top: solid 1px var(--color-neutral-100);
+  position: absolute;
+  top: 23rem; /*27 for some room */
+  width: 100%;
 }
+
+#blog-page {
+  position: relative;
+}
+

--- a/themes/umlib_blogs/templates/field/field--node--field-get-in-touch--blog-post.html.twig
+++ b/themes/umlib_blogs/templates/field/field--node--field-get-in-touch--blog-post.html.twig
@@ -55,7 +55,7 @@
     {% endfor %}
   {% endif %}
 {% else %}
-  <div{{ attributes }}>
+  <div{{ attributes.addClass('get-in-touch__block') }}>
     <h3{{ title_attributes.addClass(title_classes) }}>{{ label }}</h3>
     {% if multiple %}
       <div>

--- a/themes/umlib_blogs/templates/layout/page--a-z.html.twig
+++ b/themes/umlib_blogs/templates/layout/page--a-z.html.twig
@@ -39,7 +39,7 @@ template_preprocess_page() * @see html.html.twig */ #}
   {{ page.highlighted }}
   {{ page.help }}
 
-  <main class="viewport-container">
+  <main class="viewport-container" id="a-z-page">
     <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
   <div class="grid-two-column ">
     <div class="main-column">

--- a/themes/umlib_blogs/templates/layout/page--blog-post.html.twig
+++ b/themes/umlib_blogs/templates/layout/page--blog-post.html.twig
@@ -39,7 +39,7 @@ template_preprocess_page() * @see html.html.twig */ #}
   {{ page.highlighted }}
   {{ page.help }}
 
-  <main class="viewport-container" id="blog-page">
+  <main class="viewport-container" id="blog-post-page">
     <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
   <div class="grid-two-column">
     <div class="main-column">

--- a/themes/umlib_blogs/templates/layout/page--blog.html.twig
+++ b/themes/umlib_blogs/templates/layout/page--blog.html.twig
@@ -40,22 +40,19 @@ template_preprocess_page() * @see html.html.twig */ #}
   {{ page.help }}
 
   
-  <main  id="blog-page">
+  <main id="blog-page">
     <div class="line"></div>
-  <div class="viewport-container">
-    <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
-    <div class="blog-banner-background"></div>
-    <div class="grid-two-column-with-banner">
-   
-      {{ page.content }}
-      
-   {% if page.sidebar_first %}
-    <aside class="layout-sidebar-first sidebar-node" role="complementary">
-      {{ page.sidebar_first }}
-    </aside>
-    {% endif %}
+    <div class="viewport-container">
+      <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
+      <div class="grid-two-column-with-banner">
+        {{ page.content }}
+       {% if page.sidebar_first %}
+         <aside class="layout-sidebar-first sidebar-node" role="complementary">
+           {{ page.sidebar_first }}
+           </aside>
+        {% endif %}
+        </div>
     </div>
-  </div>
   </main>
 
   <footer class="footer">


### PR DESCRIPTION
- Blog page grid update to add `descr` as a grid area.
- Add an absolutely positioned `.line` under the blog banner. If there is not blog image, it is not good. May need an update once there are new blog banners.
- Breadcrumbs will wrap instead of stack in their container
- Jazzed up the status message (which may be annoying with a giant error log but looks nice with a small line or two and calls attention to saved changes).
- Spacing (padding and margin) all over the place
- Styling for Blog Subscription page
- Styling for Subscribe link when not logged on