### PR TITLE
Update space and line height for headings

### DIFF
--- a/themes/umlib_blogs/css/base.css
+++ b/themes/umlib_blogs/css/base.css
@@ -7,6 +7,7 @@
   border-left: none;
   padding-bottom: 0;
   padding-left: 0;
+  line-height: 1.25;
 }
 
 @media screen and (max-width: 620px)  {
@@ -22,6 +23,7 @@
   border-left: solid 4px var(--color-teal-400);
   padding-bottom: 0;
   padding-left: 1rem;
+  line-height: 1.25;
 }
 
 #blog-post-page h1 {
@@ -31,6 +33,7 @@
   border-left: solid 4px var(--color-teal-400);
   padding-bottom: 0;
   padding-left: 1rem;
+  line-height: 1.25;
 }
 
 #page-404 h1,
@@ -43,6 +46,7 @@
   border-left: solid 4px var(--color-teal-400);
   padding-bottom: 0;
   padding-left: 1rem;
+  line-height: 1.25;
 }
 
 

--- a/themes/umlib_blogs/css/component.css
+++ b/themes/umlib_blogs/css/component.css
@@ -301,8 +301,7 @@ ul.blog-tag-list {
 .blog-post-content h3, 
 .blog-post-content h4, 
 .blog-post-content h5 {
-  padding-top: 2rem;
-  padding-bottom: 1rem;
+  margin-top: 2rem;
 }
 
 /** This breaks the URL in a blog post **/


### PR DESCRIPTION
## What's New

There was too much padding around the blog-post headings and the line-height wasn't added properly for the H1s on the site.

### Currently in production
<img width="1151" alt="currently in production" src="https://github.com/mlibrary/blogs.lib/assets/29953622/1fee7463-b182-4470-8a63-4fd8c97401ff">


### With changes in this PR
<img width="1191" alt="with changes in this pr" src="https://github.com/mlibrary/blogs.lib/assets/29953622/70acddb1-a218-4afe-aff2-528d4522013d">

